### PR TITLE
Add nosalt mode for old-style secrets

### DIFF
--- a/splunksecrets.py
+++ b/splunksecrets.py
@@ -1,4 +1,5 @@
 """Command line tool for encrypting/decrypting Splunk passwords"""
+from __future__ import print_function
 
 import argparse
 import base64
@@ -26,7 +27,7 @@ def decrypt(secret, ciphertext, nosalt=False):
         plaintext = decryptor.update(ciphertext)
 
         chars = []
-        if nosalt == False:
+        if nosalt is False:
             for char1, char2 in zip(plaintext[:-1], itertools.cycle("DEFAULTSA")):
                 chars.append(six.byte2int([char1]) ^ ord(char2))
         else:
@@ -62,11 +63,11 @@ def encrypt(secret, plaintext, nosalt=False):
     key = secret[:16]
 
     chars = []
-    if nosalt == False:
+    if nosalt is False:
         for char1, char2 in zip(plaintext, itertools.cycle("DEFAULTSA")):
             chars.append(ord(char1) ^ ord(char2))
     else:
-        chars=[ord(x) for x in plaintext]
+        chars = [ord(x) for x in plaintext]
 
     chars.append(0)
 

--- a/splunksecrets.py
+++ b/splunksecrets.py
@@ -13,7 +13,7 @@ from cryptography.hazmat.primitives.ciphers import algorithms, Cipher, modes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
 
-def decrypt(secret, ciphertext,nosalt=False):
+def decrypt(secret, ciphertext, nosalt=False):
     """Given the first 16 bytes of splunk.secret, decrypt a Splunk password"""
     plaintext = None
     if ciphertext.startswith("$1$"):
@@ -30,7 +30,7 @@ def decrypt(secret, ciphertext,nosalt=False):
             for char1, char2 in zip(plaintext[:-1], itertools.cycle("DEFAULTSA")):
                 chars.append(six.byte2int([char1]) ^ ord(char2))
         else:
-            chars = [ six.byte2int(x) for x in plaintext[:-1] ]
+            chars = [six.byte2int(x) for x in plaintext[:-1]]
 
         plaintext = "".join([six.unichr(c) for c in chars])
     elif ciphertext.startswith("$7$"):
@@ -57,7 +57,7 @@ def decrypt(secret, ciphertext,nosalt=False):
     return plaintext
 
 
-def encrypt(secret, plaintext,nosalt=False):
+def encrypt(secret, plaintext, nosalt=False):
     """Given the first 16 bytes of splunk.secret, encrypt a Splunk password"""
     key = secret[:16]
 
@@ -66,7 +66,7 @@ def encrypt(secret, plaintext,nosalt=False):
         for char1, char2 in zip(plaintext, itertools.cycle("DEFAULTSA")):
             chars.append(ord(char1) ^ ord(char2))
     else:
-        chars=[ ord(x) for x in plaintext ]
+        chars=[ord(x) for x in plaintext]
 
     chars.append(0)
 
@@ -120,7 +120,7 @@ def main():  # pragma: no cover
         except KeyboardInterrupt:
             pass
         else:
-            print(decrypt(key, ciphertext,args.nosalt))
+            print(decrypt(key, ciphertext, args.nosalt))
     else:
         try:
             plaintext = getpass.getpass("Plaintext password: ")
@@ -130,4 +130,4 @@ def main():  # pragma: no cover
             if args.mode == "encrypt_new":
                 print(encrypt_new(key, plaintext))
             else:
-                print(encrypt(key, plaintext,args.nosalt))
+                print(encrypt(key, plaintext, args.nosalt))


### PR DESCRIPTION
With the "$1$" encryption method in Splunk < 7.2, there are times like `pass4SymmKey` where Splunk uses the Salt, and times like `sslPassword` in server.conf where it (for some reason) does no salting at all.

This adds a `--nosalt` argument to support those situations.  The user needs to know when something should be unsalted and when it should not, and pass the flag appropriately.