### PR TITLE
Pad short secrets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,8 @@ for AES256-GCM, with a 16-byte randomly generated initialization vector.
 The encryption produces both the ciphertext as well as a "tag" that is
 used as part of integrity verification. The iv, ciphertext, and tag (in
 that order) are concatenated, base64-encoded, and prepended with ``$7$``
-to produce the encrypted password seen in the configuration files.
+to produce the encrypted password seen in the configuration files. If
+the key is less than 254-bytes it is padded with null bytes.
 
 Phantom
 ~~~~~~~

--- a/splunksecrets.py
+++ b/splunksecrets.py
@@ -63,7 +63,7 @@ def decrypt(secret, ciphertext, nosalt=False):
         plaintext = "".join([six.unichr(c) for c in chars])
     elif ciphertext.startswith("$7$"):
         # pad secret to 254 bytes with nulls
-        secret = secret.ljust(254, b"\0")
+        secret = six.ensure_binary(secret).ljust(254, b"\0")
 
         ciphertext = b64decode(ciphertext[3:])
 
@@ -121,7 +121,7 @@ def encrypt(secret, plaintext, nosalt=False):
 def encrypt_new(secret, plaintext, iv=None):  # pylint: disable=invalid-name
     """Use the new AES 256 GCM encryption in Splunk 7.2"""
     # pad secret to 254 bytes with nulls
-    secret = secret.ljust(254, b"\0")
+    secret = six.ensure_binary(secret).ljust(254, b"\0")
 
     kdf = PBKDF2HMAC(
         algorithm=hashes.SHA256(),

--- a/splunksecrets.py
+++ b/splunksecrets.py
@@ -63,8 +63,8 @@ def decrypt(secret, ciphertext, nosalt=False):
         plaintext = "".join([six.unichr(c) for c in chars])
     elif ciphertext.startswith("$7$"):
         if len(secret) < 254:
-            print(f'secret too short ({len(secret)} bytes), padding to 254 bytes with nulls')
-            secret = secret.ljust(254, b'\0')
+            print(f"secret too short ({len(secret)} bytes), padding to 254 bytes with nulls")
+            secret = secret.ljust(254, b"\0")
         ciphertext = b64decode(ciphertext[3:])
 
         kdf = PBKDF2HMAC(
@@ -121,8 +121,8 @@ def encrypt(secret, plaintext, nosalt=False):
 def encrypt_new(secret, plaintext, iv=None):  # pylint: disable=invalid-name
     """Use the new AES 256 GCM encryption in Splunk 7.2"""
     if len(secret) < 254:
-        print(f'secret too short ({len(secret)} bytes), padding to 254 bytes with nulls')
-        secret = secret.ljust(254, b'\0')
+        print(f"secret too short ({len(secret)} bytes), padding to 254 bytes with nulls")
+        secret = secret.ljust(254, b"\0")
 
     kdf = PBKDF2HMAC(
         algorithm=hashes.SHA256(),

--- a/splunksecrets.py
+++ b/splunksecrets.py
@@ -62,9 +62,9 @@ def decrypt(secret, ciphertext, nosalt=False):
 
         plaintext = "".join([six.unichr(c) for c in chars])
     elif ciphertext.startswith("$7$"):
-        if len(secret) < 254:
-            print(f"secret too short ({len(secret)} bytes), padding to 254 bytes with nulls")
-            secret = secret.ljust(254, b"\0")
+        # pad secret to 254 bytes with nulls
+        secret = secret.ljust(254, b"\0")
+
         ciphertext = b64decode(ciphertext[3:])
 
         kdf = PBKDF2HMAC(
@@ -120,9 +120,8 @@ def encrypt(secret, plaintext, nosalt=False):
 
 def encrypt_new(secret, plaintext, iv=None):  # pylint: disable=invalid-name
     """Use the new AES 256 GCM encryption in Splunk 7.2"""
-    if len(secret) < 254:
-        print(f"secret too short ({len(secret)} bytes), padding to 254 bytes with nulls")
-        secret = secret.ljust(254, b"\0")
+    # pad secret to 254 bytes with nulls
+    secret = secret.ljust(254, b"\0")
 
     kdf = PBKDF2HMAC(
         algorithm=hashes.SHA256(),

--- a/splunksecrets.py
+++ b/splunksecrets.py
@@ -357,6 +357,8 @@ def __load_splunk_secret(ctx, param, value):  # pragma: no cover
     if ctx.get_parameter_source(param.name).name != "ENVIRONMENT":
         with open(value, "rb") as f:  # pylint: disable=invalid-name
             value = f.read().strip()
+    elif isinstance(value, str):
+        value = bytes(value, encoding="utf-8")
 
     return value.strip()
 

--- a/splunksecrets.py
+++ b/splunksecrets.py
@@ -63,7 +63,8 @@ def decrypt(secret, ciphertext, nosalt=False):
         plaintext = "".join([six.unichr(c) for c in chars])
     elif ciphertext.startswith("$7$"):
         if len(secret) < 254:
-            raise ValueError(f"secret too short, need 254 bytes, got {len(secret)}")
+            print(f'secret too short ({len(secret)} bytes), padding to 254 bytes with nulls')
+            secret = secret.ljust(254, b'\0')
         ciphertext = b64decode(ciphertext[3:])
 
         kdf = PBKDF2HMAC(
@@ -120,7 +121,8 @@ def encrypt(secret, plaintext, nosalt=False):
 def encrypt_new(secret, plaintext, iv=None):  # pylint: disable=invalid-name
     """Use the new AES 256 GCM encryption in Splunk 7.2"""
     if len(secret) < 254:
-        raise ValueError(f"secret too short, need 254 bytes, got {len(secret)}")
+        print(f'secret too short ({len(secret)} bytes), padding to 254 bytes with nulls')
+        secret = secret.ljust(254, b'\0')
 
     kdf = PBKDF2HMAC(
         algorithm=hashes.SHA256(),

--- a/tests.py
+++ b/tests.py
@@ -105,10 +105,13 @@ class TestSplunkSecrets(unittest.TestCase):
         )
         self.assertEqual(ciphertext, "$7$aTVkS01HYVNJUk5wSnR5NKR+EdOfT4t84WSiXvPFHGHsfHtbgPIL3g==")
 
-    def test_encrypt_new_raises_value_error_short_secret(self):
-        with self.assertRaises(ValueError):
-            splunk_secret = base64.b64encode(os.urandom(255))[:253]
-            splunksecrets.encrypt_new(splunk_secret, "temp1234")
+    def test_encrypt_new_pads_short_secret(self):
+        ciphertext = splunksecrets.encrypt_new(
+            splunk_secret[:30],
+            "short123",
+            iv=six.b("4KK0Ra8LWBKxUFQ8")
+        )
+        self.assertEqual(ciphertext, "$7$NEtLMFJhOExXQkt4VUZROK9vm0tDLbJn2jxESMRbs7MTdiHuTtBz8g==")
 
     def test_encrypt_character_matches_salt1(self):
         ciphertext = splunksecrets.encrypt(splunk_secret, "A" * 8)

--- a/tests.py
+++ b/tests.py
@@ -141,7 +141,6 @@ class TestSplunkSecrets(unittest.TestCase):
         )
         self.assertEqual(plaintext, "short123")
 
-
     def test_decrypt_nosalt(self):
         plaintext = splunksecrets.decrypt(splunk_secret, "$1$2+1yGuQ1gcMK", nosalt=True)
         self.assertEqual(plaintext, "temp1234")

--- a/tests.py
+++ b/tests.py
@@ -105,6 +105,14 @@ class TestSplunkSecrets(unittest.TestCase):
         )
         self.assertEqual(ciphertext, "$7$aTVkS01HYVNJUk5wSnR5NKR+EdOfT4t84WSiXvPFHGHsfHtbgPIL3g==")
 
+    def test_encrypt_new_str_secret(self):
+        ciphertext = splunksecrets.encrypt_new(
+            "abc123",  # secret as a string (not bytes)
+            "strings are fine",
+            iv=six.b("zIDM0YmIgDQ2gMzk")
+        )
+        self.assertEqual(ciphertext, "$7$eklETTBZbUlnRFEyZ016a+2HMVEtbCAJkNb7RkVHdqZwZkVJyZ+HmTWlYJedFdR4")
+
     def test_encrypt_new_pads_short_secret(self):
         ciphertext = splunksecrets.encrypt_new(
             splunk_secret[:30],

--- a/tests.py
+++ b/tests.py
@@ -134,13 +134,13 @@ class TestSplunkSecrets(unittest.TestCase):
             splunk_secret = base64.b64encode(os.urandom(255))[:15]
             splunksecrets.decrypt(splunk_secret, "$1$n6g0W7F51ZAK")
 
-    def test_decrypt_raises_value_error_short_secret2(self):
-        with self.assertRaises(ValueError):
-            splunk_secret = base64.b64encode(os.urandom(255))[:253]
-            splunksecrets.decrypt(
-                splunk_secret,
-                "$7$aTVkS01HYVNJUk5wSnR5NKR+EdOfT4t84WSiXvPFHGHsfHtbgPIL3g=="
-            )
+    def test_decrypt_pads_short_secret2(self):
+        plaintext = splunksecrets.decrypt(
+            splunk_secret[:30],
+            "$7$NEtLMFJhOExXQkt4VUZROK9vm0tDLbJn2jxESMRbs7MTdiHuTtBz8g=="
+        )
+        self.assertEqual(plaintext, "short123")
+
 
     def test_decrypt_nosalt(self):
         plaintext = splunksecrets.decrypt(splunk_secret, "$1$2+1yGuQ1gcMK", nosalt=True)


### PR DESCRIPTION
This PR updates the `encrypt_new` and `decrypt` (for Splunk 7.2 or later secrets) functions to pad the `splunk.secret` to 254 bytes if the file is less than 254 bytes.

If we strace a `splunk show-encrypted` call, we can see that the splunkd binary does the same padding for short secrets. When this happens it also writes a _Read custom key data size=[bytes]_ message to stderr.

```sh
[root@91d3c9294444 splunk]# strace -f /opt/splunk/bin/splunk show-encrypted --value 'foo'
<...SNIP...>
[pid 50471] openat(AT_FDCWD, "/opt/splunk/etc/auth/splunk.secret", O_RDONLY) = 3
[pid 50471] read(3, "notarealsecret", 254) = 14  # << we only read 14 bytes ("notarealsecret") from /opt/splunk/etc/auth/splunk.secret
[pid 50471] read(3, "", 240)            = 0      # << we read 240 bytes of nulls (14+240 = 254 bytes)
[pid 50471] write(2, "Read custom key data size=14\n", 29Read custom key data size=14) = 29
[pid 50471] stat("/opt/splunk/etc/auth/splunk.secret", {st_mode=S_IFREG|0400, st_size=14, ...}) = 0
[pid 50471] close(3)                    = 0
<...SNIP...>
```

If the contents of `splunk.secret` are 254 bytes (or more) it only reads 254 bytes and doesn't output the custom key data size message. Both of these cases are already covered by `splunksecrets.py`.

## Testing

I've updated the tests accordingly but for manual testing I used a [`splunk/splunk`](https://hub.docker.com/r/splunk/splunk/) container and the updated `splunksecrets.py`:

```sh
# docker container and local have the same splunk.secret
$ cat splunk.secret && echo
notarealsecret
$ docker exec -it splunk sudo cat /opt/splunk/etc/auth/splunk.secret && echo
notarealsecret

# we can encrypt with splunksecrets and decrypt with splunk show-decrypted
$ splunksecrets splunk-encrypt --splunk-secret splunk.secret --password '1: from splunksecrets to splunk'
secret too short (14 bytes), padding to 254 bytes with nulls
$7$AxDuMlIUPIn76nBAbnLDC7RI8av2L08ZTZpMWrI+vu94WzFPFq1343ZomUP5NNf53ndGrKpYgs0Rpgo7vMVW
$ docker exec -it splunk sudo /opt/splunk/bin/splunk show-decrypted --value '$7$AxDuMlIUPIn76nBAbnLDC7RI8av2L08ZTZpMWrI+vu94WzFPFq1343ZomUP5NNf53ndGrKpYgs0Rpgo7vMVW'
Read custom key data size=14
1: from splunksecrets to splunk

# and we can encrypt with splunk show-encrypted and decrypt with splunksecrets
$ docker exec -it splunk sudo /opt/splunk/bin/splunk show-encrypted --value '2: from splunk to splunksecrets' && echo
Read custom key data size=14
$7$71DoIvj4k5ATEFRBUMWjfap+u2Jqq6Xd+ypAOUi516enJ2KD0zjuWYmYb2cASjzthdYgUPIKREjnAsERqtqL
$ splunksecrets splunk-decrypt --splunk-secret splunk.secret --ciphertext '$7$71DoIvj4k5ATEFRBUMWjfap+u2Jqq6Xd+ypAOUi516enJ2KD0zjuWYmYb2cASjzthdYgUPIKREjnAsERqtqL'
secret too short (14 bytes), padding to 254 bytes with nulls
2: from splunk to splunksecrets
```