### PR TITLE
Update short secret raise tests

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -93,7 +93,7 @@ class TestSplunkSecrets(unittest.TestCase):
         self.assertEqual(ciphertext, "$1$2+1yGuQ1gcMK")
 
     def test_encrypt_raises_value_error_short_secret(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "^secret too short, need 16 bytes, got 15$"):
             splunk_secret = base64.b64encode(os.urandom(255))[:15]
             splunksecrets.encrypt(splunk_secret, "temp1234")
 
@@ -127,7 +127,7 @@ class TestSplunkSecrets(unittest.TestCase):
         self.assertEqual(plaintext, "temp1234")
 
     def test_decrypt_raises_value_error_short_secret1(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, "^secret too short, need 16 bytes, got 15$"):
             splunk_secret = base64.b64encode(os.urandom(255))[:15]
             splunksecrets.decrypt(splunk_secret, "$1$n6g0W7F51ZAK")
 


### PR DESCRIPTION
This PR updates the `test_encrypt_raises_value_error_short_secret` and `test_decrypt_raises_value_error_short_secret1` tests to match the raised `ValueError` string.

This should prevent cases where something is raising but in the way it's expected to.

## :mag: References

- cc https://github.com/HurricaneLabs/splunksecrets/pull/14#issuecomment-2379555665
- cc https://docs.python.org/3/library/unittest.html#unittest.TestCase.assertRaisesRegex