### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           fetch-depth: 2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
           - "3.11"
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
This PR updates `actions/checkout` and `actions/setup-python` to their latest versions.

This resolves the following deprecation warnings:

<img width="664" alt="Screenshot 2024-11-04 at 12 44 51 PM" src="https://github.com/user-attachments/assets/535e090d-b483-41ee-b269-6453b7403e65">