### PR TITLE
Resolve ARC4 `CryptographyDeprecationWarning`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     long_description=long_description,
     install_requires=[
         "click>=8.0.0",
-        "cryptography>=3.2",
+        "cryptography>=43",
         "pcrypt",
         "six>=1.12.0"
     ],

--- a/splunksecrets.py
+++ b/splunksecrets.py
@@ -11,6 +11,7 @@ import click
 import pcrypt
 import six
 from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.decrepit.ciphers.algorithms import ARC4
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.ciphers import algorithms, Cipher, modes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
@@ -45,7 +46,7 @@ def decrypt(secret, ciphertext, nosalt=False):
             raise ValueError(f"secret too short, need 16 bytes, got {len(secret)}")
         key = secret[:16]
 
-        algorithm = algorithms.ARC4(key)
+        algorithm = ARC4(key)
         cipher = Cipher(algorithm, mode=None, backend=default_backend())
         decryptor = cipher.decryptor()
         plaintext = decryptor.update(ciphertext)
@@ -109,7 +110,7 @@ def encrypt(secret, plaintext, nosalt=False):
 
     plaintext = b"".join([six.int2byte(c) for c in chars])
 
-    algorithm = algorithms.ARC4(key)
+    algorithm = ARC4(key)
     cipher = Cipher(algorithm, mode=None, backend=default_backend())
     encryptor = cipher.encryptor()
     ciphertext = encryptor.update(plaintext)


### PR DESCRIPTION
This PR resolves a `CryptographyDeprecationWarning` warning as `algorithms.ARC4` [moved in cryptography>=43](https://github.com/pyca/cryptography/blob/57b304996e9ecbafb79b2161f1f7f65c901392ef/CHANGELOG.rst?plain=1#L71-L74). Alternatively the install dependency could be updated to `cryptography>=3.2,cryptography<43`.

<img width="849" alt="Screenshot 2024-11-04 at 1 27 53 PM" src="https://github.com/user-attachments/assets/b3eac503-3f4c-4cf9-964e-0cbb8724f2b2">

## :mag: References

- cc https://github.com/HurricaneLabs/splunksecrets/actions/runs/11636944661/job/32409272880#step:5:22
- cc https://github.com/pyca/cryptography/commit/722a6393e61b3acb569f404218f213fe08478a96#diff-2c623f3c6a917be56c59d43279244996836262cb1e12d9d0786c9c49eef6b43c