### PR TITLE
Specify open encoding (W1514)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 VERSION = "1.0.1"
 
 
-with open("README.rst", "r") as f:
+with open("README.rst", "r", encoding="utf-8") as f:
     long_description = f.read()
 
 


### PR DESCRIPTION
This PR adds an encoding to the `open()` call in `setup.py`. This resolves a potential issue with an [unspecified-encoding](https://pylint.readthedocs.io/en/latest/user_guide/messages/warning/unspecified-encoding.html).